### PR TITLE
a̶d̶d̶e̶d̶ ̶s̶l̶i̶c̶e̶(̶1̶)̶ ̶t̶o̶ ̶p̶r̶i̶v̶a̶t̶e̶K̶e̶y̶B̶u̶f̶f̶e̶r̶ (This is depreciated as the issue is fixed in next version)

### DIFF
--- a/src/wallet-client.js
+++ b/src/wallet-client.js
@@ -88,7 +88,7 @@ module.exports = class WalletClient {
       privateKeyBuffer[i / 2] = parseInt(privateKey.substr(i, 2), 16);
     }
 
-    return new AptosAccount(privateKeyBuffer, "");
+    return new AptosAccount(privateKeyBuffer.slice(1), "");
   }
 
   /**


### PR DESCRIPTION
privateKeyBuffer was of length 65, when aptos needs 64 buffer length private key, there was an extra 0 in the start, so i am using slice(1) but more better option will be to use `HexString.ensure().toUint8Array()`